### PR TITLE
fix:  the email variable appears as "$email" instead of displaying the actual email after clicking resend.  #3

### DIFF
--- a/src/Http/Controllers/Auth/VerifyEmailController.php
+++ b/src/Http/Controllers/Auth/VerifyEmailController.php
@@ -40,6 +40,6 @@ class VerifyEmailController extends Controller
 
         $request->user()->sendEmailVerificationNotification();
 
-        return back()->with('success', __('waterhole::auth.email-verification-sent-message'));
+        return back()->with('success', __('waterhole::auth.email-verification-sent-message', ['email' => $request->user()->email]));
     }
 }


### PR DESCRIPTION
### Bug description

This will fix: 
Issue reference #3 : Untranslated text variable

### Detailed Description:
 When users click on the resend button, the email variable appears as "$email" instead of displaying the actual email address.

Steps to reproduce:

1. Sign up
2. Click on the resend email button. 

![waterhole_issue](https://github.com/waterholeforum/core/assets/43740952/2a5b0084-6574-446b-b89b-3f48c5ea2cc0)

**After Fix:**
<img width="943" alt="waterhole_after_fix" src="https://github.com/waterholeforum/core/assets/43740952/37af5993-dc8e-4d25-8c4a-c1a7c90d12ff">

Environment:

> local
> https://waterhole.dev/community

**The fix:**
In  `Auth/VerifyEmailController.php` `resend` function, we were not passing the `email`  in the `back()->with()` method. I added that.  
