### PR TITLE
(fix) Fallback to base translator for translation striongs as keys

### DIFF
--- a/src/Translation/FluentTranslator.php
+++ b/src/Translation/FluentTranslator.php
@@ -77,26 +77,21 @@ final class FluentTranslator implements TranslatorContract
                 continue;
             }
 
-            if (!str_contains($k, '.')) {
-                if ($this->baseTranslator->has($k, $locale, $fallback)) {
-                    return $this->baseTranslator->get($k, $replace, $locale, $fallback);
+            if (str_contains($k, '.')) {
+                [$namespace, $group, $item] = $this->parseKey($k);
+
+                $message = $this->getBundle($namespace, $locale, $group)?->message($item, $replace);
+
+                if ($fallback && $this->fallback !== $locale) {
+                    $message ??= $this->getBundle($namespace, $this->fallback, $group)?->message(
+                        $item,
+                        $replace,
+                    );
                 }
-                continue;
-            }
 
-            [$namespace, $group, $item] = $this->parseKey($k);
-
-            $message = $this->getBundle($namespace, $locale, $group)?->message($item, $replace);
-
-            if ($fallback && $this->fallback !== $locale) {
-                $message ??= $this->getBundle($namespace, $this->fallback, $group)?->message(
-                    $item,
-                    $replace,
-                );
-            }
-
-            if ($message) {
-                return $message;
+                if ($message) {
+                    return $message;
+                }
             }
 
             if ($this->baseTranslator->has($k, $locale, $fallback)) {

--- a/src/Translation/FluentTranslator.php
+++ b/src/Translation/FluentTranslator.php
@@ -73,7 +73,14 @@ final class FluentTranslator implements TranslatorContract
         $keys = (array) $key;
 
         foreach ($keys as $k) {
-            if (!$k || !str_contains($k, '.')) {
+            if (!$k) {
+                continue;
+            }
+
+            if (!str_contains($k, '.')) {
+                if ($this->baseTranslator->has($k, $locale, $fallback)) {
+                    return $this->baseTranslator->get($k, $replace, $locale, $fallback);
+                }
                 continue;
             }
 


### PR DESCRIPTION
When using [translation strings as keys](https://laravel.com/docs/10.x/localization#using-translation-strings-as-keys) in a Laravel app, a key does not require dots in it. The current code would lead to untranslated strings - even outside the Waterhole routes.

This PR will fallback to the base translator for those keys.  