### PR TITLE
Fallback to resource directory for translation bundle

### DIFF
--- a/src/Translation/FluentTranslator.php
+++ b/src/Translation/FluentTranslator.php
@@ -182,9 +182,9 @@ final class FluentTranslator implements TranslatorContract
                 return $bundle;
             }
 
-            // If there is no bundle in the namespace for the locale, try to load it from the
-            // resource directory.
-            return $this->loadPath("{$this->path}/vendor/{$namespace}/", $locale, $group);
+            if ($this->bundleOptions['allowOverrides'] ?? false) {
+                return $this->loadPath("{$this->path}/vendor/{$namespace}", $locale, $group);
+            }
         }
 
         return false;

--- a/src/Translation/FluentTranslator.php
+++ b/src/Translation/FluentTranslator.php
@@ -183,7 +183,7 @@ final class FluentTranslator implements TranslatorContract
             }
 
             // If there is no bundle in the namespace for the locale, try to load it from the
-            // ressource directory.
+            // resource directory.
             return $this->loadPath("{$this->path}/vendor/{$namespace}/", $locale, $group);
         }
 

--- a/src/Translation/FluentTranslator.php
+++ b/src/Translation/FluentTranslator.php
@@ -181,6 +181,10 @@ final class FluentTranslator implements TranslatorContract
 
                 return $bundle;
             }
+
+            // If there is no bundle in the namespace for the locale, try to load it from the
+            // ressource directory.
+            return $this->loadPath("{$this->path}/vendor/{$namespace}/", $locale, $group);
         }
 
         return false;


### PR DESCRIPTION
Currently, if a locale (e.g., `﻿de`) is not available in the core package, the translation bundle located in ﻿`resources/lang/vendor/waterhole/de/` would not be loaded.

This PR aims to fix this issue by falling back to the resource path and loading the bundle.