### PR TITLE
Fix implicit nullable deprecation warning in 8.4

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -110,7 +110,7 @@ function resolve_all(array $names, array ...$parameters): array
     );
 }
 
-function return_field(string $default = null): string
+function return_field(?string $default = null): string
 {
     return '<input type="hidden" name="return" value="' .
         old('return', request('return', $default)) .


### PR DESCRIPTION
Fixes PHP 8.4 deprecation warning in `core/src/helpers.php` on line 113: `Implicitly marking parameter $default as nullable is deprecated, the explicit nullable type must be used instead`

Resolves #84 