### PR TITLE
Use `DateTimeInterface` to support `CarbonImmutable` dates

### DIFF
--- a/src/View/Components/Attribution.php
+++ b/src/View/Components/Attribution.php
@@ -2,7 +2,7 @@
 
 namespace Waterhole\View\Components;
 
-use DateTime;
+use DateTimeInterface;
 use Illuminate\View\Component;
 use Waterhole\Models\User;
 
@@ -10,7 +10,7 @@ class Attribution extends Component
 {
     public function __construct(
         public ?User $user,
-        public ?DateTime $date = null,
+        public ?DateTimeInterface $date = null,
         public ?string $permalink = null,
     ) {
     }

--- a/src/View/Components/RelativeTime.php
+++ b/src/View/Components/RelativeTime.php
@@ -3,14 +3,14 @@
 namespace Waterhole\View\Components;
 
 use Carbon\Carbon;
-use DateTime;
+use DateTimeInterface;
 use Illuminate\View\Component;
 
 class RelativeTime extends Component
 {
     public ?Carbon $dateTime;
 
-    public function __construct(?DateTime $datetime)
+    public function __construct(?DateTimeInterface $datetime)
     {
         $this->dateTime = $datetime ? new Carbon($datetime) : null;
     }


### PR DESCRIPTION
Laravel can be configured to use immutable Carbon dates with `Date::use(CarbonImmutable::class)`.

`DateTimeInterface` is the common interface for `DateTime` and `DateTimeImmutable`.

This commit updates `DateTime`-typed parameters to `DateTimeInterface` to support immutable dates.