### PR TITLE
Fix CJK heading slugs and fragment navigation

### DIFF
--- a/resources/js/bootstrap/turbo.ts
+++ b/resources/js/bootstrap/turbo.ts
@@ -42,6 +42,9 @@ document.addEventListener('click', (e) => {
 
     if (!link) return;
 
+    if (link.target && link.target !== '_self') return;
+    if (link.hasAttribute('download')) return;
+
     const url = new URL(link.href, window.location.href);
 
     if (
@@ -60,7 +63,16 @@ document.addEventListener('click', (e) => {
 
     e.preventDefault();
 
+    const oldURL = window.location.href;
+
     history.pushState(null, '', url.href);
+
+    window.dispatchEvent(
+        new HashChangeEvent('hashchange', {
+            oldURL,
+            newURL: window.location.href,
+        }),
+    );
 
     element.scrollIntoView({
         behavior: 'auto',

--- a/resources/js/bootstrap/turbo.ts
+++ b/resources/js/bootstrap/turbo.ts
@@ -28,10 +28,52 @@ document.addEventListener('turbo:load', () => {
     );
 });
 
+document.addEventListener('click', (e) => {
+    if (!(e instanceof MouseEvent)) return;
+    if (e.defaultPrevented) return;
+    if (e.button !== 0) return;
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+
+    const target = e.target;
+
+    if (!(target instanceof Element)) return;
+
+    const link = target.closest<HTMLAnchorElement>('a[href*="#"]');
+
+    if (!link) return;
+
+    const url = new URL(link.href, window.location.href);
+
+    if (
+        url.origin !== window.location.origin ||
+        url.pathname !== window.location.pathname ||
+        url.search !== window.location.search ||
+        !url.hash
+    ) {
+        return;
+    }
+
+    const id = decodeURIComponent(url.hash.slice(1));
+    const element = document.getElementById(id);
+
+    if (!element) return;
+
+    e.preventDefault();
+
+    history.pushState(null, '', url.href);
+
+    element.scrollIntoView({
+        behavior: 'auto',
+        block: 'start',
+    });
+});
+
 document.addEventListener('turbo:morph', async () => {
     await nextFrame();
     if (!window.location.hash) return;
-    document.querySelector(window.location.hash)?.scrollIntoView();
+
+    const id = decodeURIComponent(window.location.hash.slice(1));
+    document.getElementById(id)?.scrollIntoView();
 });
 
 document.addEventListener('turbo:before-morph-element', (e) => {

--- a/resources/js/controllers/scrollspy-controller.ts
+++ b/resources/js/controllers/scrollspy-controller.ts
@@ -134,7 +134,7 @@ export default class extends Controller<HTMLElement> {
     }
 
     private target(a: HTMLAnchorElement) {
-        const id = a.hash.substring(1);
+        const id = decodeURIComponent(a.hash.slice(1));
 
         return id ? document.getElementById(id) : null;
     }

--- a/src/Formatter/HeadingSlugs.php
+++ b/src/Formatter/HeadingSlugs.php
@@ -5,6 +5,7 @@ namespace Waterhole\Formatter;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use s9e\TextFormatter\Configurator;
+use s9e\TextFormatter\Parser\Tag as ParserTag;
 use s9e\TextFormatter\Utils;
 use s9e\TextFormatter\Utils\ParsedDOM;
 use Throwable;
@@ -17,17 +18,141 @@ abstract class HeadingSlugs
 
     /**
      * Formatter configuration callback.
+     *
+     * Use Litedown's normal heading ID generation, but replace its
+     * ASCII-only slugger with a Unicode-aware implementation.
      */
     public static function configure(Configurator $config): void
     {
         $config->Litedown->addHeadersId(static::PREFIX);
+
+        foreach (range(1, 6) as $level) {
+            $tag = $config->tags['H' . $level];
+
+            if (!$tag) {
+                continue;
+            }
+
+            static::replaceSlugFilter($tag);
+        }
+    }
+
+    /**
+     * Replace Litedown's default ASCII-only slug filter.
+     */
+    protected static function replaceSlugFilter($tag): void
+    {
+        $filterChain = $tag->filterChain;
+
+        /*
+         * Litedown::addHeadersId() appends its Slugger as the final
+         * filter in the chain:
+         *
+         * Slugger::setTagSlug($tag, $innerText)
+         *
+         * Remove that filter before adding our Unicode-aware version.
+         */
+        if (count($filterChain) > 0) {
+            $last = count($filterChain) - 1;
+
+            if (
+                $filterChain[$last]->getCallback()
+                === 's9e\\TextFormatter\\Plugins\\Litedown\\Parser\\Slugger::setTagSlug'
+            ) {
+                $filterChain->delete($last);
+            }
+        }
+
+        /*
+         * Important:
+         *
+         * TagFilter defaults to passing only $tag.
+         * We explicitly declare both $tag and $innerText because
+         * setTagSlug() needs the heading text as its second argument.
+         */
+        $filter = $filterChain->append(
+            static::class . '::setTagSlug($tag, $innerText)'
+        );
+
+        $filter->setJS(<<<'JS'
+function filterTag(tag, innerText)
+{
+    let slug = innerText.toLowerCase();
+
+    // Keep Unicode letters and numbers.
+    slug = slug.replace(/[^\p{L}\p{N}]+/gu, '-');
+
+    // Remove leading/trailing separators.
+    slug = slug.replace(/^-+/, '').replace(/-+$/, '');
+
+    if (slug !== '')
+    {
+        tag.setAttribute('slug', slug);
+    }
+}
+JS);
+    }
+
+    /**
+     * Generate a Unicode-safe heading slug.
+     *
+     * Examples:
+     *
+     * PHP 設定       -> php-設定
+     * 中文設定        -> 中文設定
+     * PHP 8.5 設定   -> php-8-5-設定
+     * Hello, 世界!   -> hello-世界
+     */
+    public static function setTagSlug(
+        ParserTag $tag,
+        string $innerText,
+    ): void {
+        $slug = trim($innerText);
+
+        if ($slug === '') {
+            return;
+        }
+
+        /*
+         * Unicode-aware lowercase.
+         *
+         * mb_strtolower() is preferred because it handles Unicode
+         * case conversion correctly.
+         */
+        if (function_exists('mb_strtolower')) {
+            $slug = mb_strtolower($slug, 'UTF-8');
+        } else {
+            $slug = strtolower($slug);
+        }
+
+        /*
+         * Keep Unicode letters (\p{L}) and numbers (\p{N}).
+         * Everything else becomes a single "-".
+         */
+        $slug = preg_replace(
+            '/[^\p{L}\p{N}]+/u',
+            '-',
+            $slug,
+        );
+
+        if ($slug === null) {
+            return;
+        }
+
+        $slug = trim($slug, '-');
+
+        if ($slug !== '') {
+            $tag->setAttribute('slug', $slug);
+        }
     }
 
     /**
      * Extract headings from parsed XML.
      */
-    public static function extractHeadings(?string $xml, array $levels = [2, 3]): Collection
-    {
+    public static function extractHeadings(
+        ?string $xml,
+        array $levels = [2, 3],
+    ): Collection {
         if (!$xml) {
             return collect();
         }
@@ -42,16 +167,23 @@ abstract class HeadingSlugs
             return collect();
         }
 
-        $query = collect($levels)->map(fn($level) => "//H{$level}[@slug]")->implode(' | ');
+        $query = collect($levels)
+            ->map(fn($level) => "//H{$level}[@slug]")
+            ->implode(' | ');
 
         return collect($dom->query($query))
             ->map(function ($heading) {
                 $slug = trim($heading->getAttribute('slug'));
-                $text = trim(preg_replace(
-                    '/\s+/',
-                    ' ',
-                    remove_formatting('<r>' . $heading->C14N() . '</r>'),
-                ));
+
+                $text = trim(
+                    preg_replace(
+                        '/\s+/',
+                        ' ',
+                        remove_formatting(
+                            '<r>' . $heading->C14N() . '</r>',
+                        ),
+                    ),
+                );
 
                 return [
                     'level' => strtolower($heading->nodeName),
@@ -76,10 +208,14 @@ abstract class HeadingSlugs
         }
 
         foreach ($levels as $level) {
-            $xml = Utils::replaceAttributes($xml, "H$level", fn(array $attributes) => Arr::except(
-                $attributes,
-                'slug',
-            ));
+            $xml = Utils::replaceAttributes(
+                $xml,
+                "H$level",
+                fn(array $attributes) => Arr::except(
+                    $attributes,
+                    'slug',
+                ),
+            );
         }
 
         return $xml;

--- a/tests/Feature/Formatter/HeadingSlugsTest.php
+++ b/tests/Feature/Formatter/HeadingSlugsTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Waterhole\Formatter\Formatter;
+
+test('preserves chinese characters in heading slugs', function () {
+    $formatter = app(Formatter::class);
+
+    $formatter->flush();
+
+    $xml = $formatter->parse('## PHP 設定');
+
+    expect($xml)->toContain('slug="php-設定"');
+});
+
+test('preserves chinese-only heading slugs', function () {
+    $formatter = app(Formatter::class);
+
+    $formatter->flush();
+
+    $xml = $formatter->parse('## 中文設定');
+
+    expect($xml)->toContain('slug="中文設定"');
+});


### PR DESCRIPTION
## Summary

* Fix CJK/Unicode heading slugs in Waterhole
* Preserve Unicode letters and numbers when generating heading slugs
* Fix same-page fragment navigation for percent-encoded Unicode heading IDs
* Decode URL fragments before resolving heading elements with `getElementById()`
* Add tests for Chinese heading slugs

## Problem

Waterhole's default Litedown heading slug generation is ASCII-oriented, which can cause CJK heading text to produce empty or incomplete slugs.

For example:

```text
PHP 設定
```

can now generate:

```text
content-php-設定
```

instead of losing the Chinese characters.

There is also a related client-side issue when navigating to Unicode heading fragments.

The URL representation of a Unicode fragment may be percent-encoded:

```text
#content-3-3-sub-section-c-%E5%AD%90%E7%B3%BB%E7%B5%B1-c
```

while the corresponding DOM element has a decoded Unicode `id`:

```html
id="content-3-3-sub-section-c-子系統-c"
```

The fragment is now decoded before resolving the target element with `getElementById()`, allowing Unicode heading anchors to navigate correctly.

## Changes

### PHP

Replaced the default Litedown heading slug filter with a Unicode-aware implementation using Unicode character classes:

* `\p{L}` — Unicode letters
* `\p{N}` — Unicode numbers

Examples:

```text
PHP 設定       → php-設定
中文設定        → 中文設定
PHP 8.5 設定   → php-8-5-設定
Hello, 世界!   → hello-世界
```

### TypeScript

Updated the scrollspy target resolution to decode percent-encoded URL fragments before calling `getElementById()`.

Also added explicit same-page fragment navigation handling so Unicode heading links are resolved against their decoded DOM IDs.

This avoids relying on CSS selector parsing for Unicode/encoded fragments and ensures that links such as:

```text
#content-3-3-sub-section-c-%E5%AD%90%E7%B3%BB%E7%B5%B1-c
```

correctly resolve to:

```text
id="content-3-3-sub-section-c-子系統-c"
```

## Testing

* Tested successfully on a separate Waterhole environment
* Verified Chinese heading slugs are generated correctly
* Verified CJK heading anchors navigate correctly
* Verified scrollspy correctly identifies Unicode heading targets
* Added `HeadingSlugsTest`
* Ran `git diff --check` successfully
* Verified the compiled JavaScript contains the updated Unicode fragment handling
