### PR TITLE
Fix PostgreSQL compatibility issues

### DIFF
--- a/src/Http/Controllers/Forum/NotificationController.php
+++ b/src/Http/Controllers/Forum/NotificationController.php
@@ -28,8 +28,15 @@ class NotificationController extends Controller
 
         $user->update(['notifications_read_at' => now()]);
 
-        $groupType = "COALESCE(group_type, CONCAT('', id))";
-        $groupId = "COALESCE(group_id, CONCAT('', id))";
+        $isPgsql = $user->getConnection()->getDriverName() === 'pgsql';
+
+        if ($isPgsql) {
+            $groupType = 'COALESCE(group_type, id::text)';
+            $groupId = 'COALESCE(group_id::text, id::text)';
+        } else {
+            $groupType = "COALESCE(group_type, CONCAT('', id))";
+            $groupId = "COALESCE(group_id, CONCAT('', id))";
+        }
 
         // Notifications can be grouped together by their subject. When listing
         // notifications, we only show the most recent notification in each

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -343,12 +343,21 @@ class User extends Model implements
                 $query->where('notifications.created_at', '>', $this->notifications_read_at);
             }
 
-            $groupType = "COALESCE(group_type, CONCAT('', id))";
-            $groupId = "COALESCE(group_id, CONCAT('', id))";
+            $isPgsql = $this->getConnection()->getDriverName() === 'pgsql';
+
+            if ($isPgsql) {
+                $groupType = 'COALESCE(group_type, id::text)';
+                $groupId = 'COALESCE(group_id::text, id::text)';
+                $countExpression = "type || '\x1f' || $groupType || '\x1f' || $groupId";
+            } else {
+                $groupType = "COALESCE(group_type, CONCAT('', id))";
+                $groupId = "COALESCE(group_id, CONCAT('', id))";
+                $countExpression = "CONCAT(type, '\x1f', $groupType, '\x1f', $groupId)";
+            }
 
             return $query
                 ->distinct()
-                ->count(new Expression("CONCAT(type, '\x1f', $groupType, '\x1f', $groupId)"));
+                ->count(new Expression($countExpression));
         })->shouldCache();
     }
 

--- a/src/Search/FullTextSearchEngine.php
+++ b/src/Search/FullTextSearchEngine.php
@@ -71,22 +71,25 @@ class FullTextSearchEngine implements EngineInterface
         // multiple relevant comments inside.
         $query->select(['posts.id as post_id', 'posts.title', 'posts.body as post_body']);
         $score = [];
+        $scoreExpressions = [];
 
         if (in_array('title', $in)) {
             $score[] = 'tscore';
             $sql = $this->getScoreSql($isPgsql, $grammar->wrap('posts.title'));
             $query->selectRaw("$sql * 10 as tscore", [$q]);
+            $scoreExpressions[] = "$sql * 10";
         }
 
         if (in_array('body', $in)) {
             $score[] = 'pscore';
             $sql = $this->getScoreSql($isPgsql, $grammar->wrap('posts.body'));
             $query->selectRaw("$sql as pscore", [$q]);
+            $scoreExpressions[] = $sql;
         }
 
         if (in_array('comments', $in)) {
             $score[] = 'cscore';
-            $sql = $this->getScoreSql($isPgsql, $grammar->wrap('posts.body'));
+            $sql = $this->getScoreSql($isPgsql, $grammar->wrap('comments.body'));
             $query
                 ->addSelect('comments.id as comment_id')
                 ->addSelect('comments.body as comment_body')
@@ -97,6 +100,8 @@ class FullTextSearchEngine implements EngineInterface
                     [$q],
                 )
                 ->selectRaw("$sql as cscore", [$q]);
+
+            $scoreExpressions[] = $sql;
         } else {
             $query->selectRaw('1 as r');
         }
@@ -111,8 +116,13 @@ class FullTextSearchEngine implements EngineInterface
                 break;
 
             default:
-                if ($score) {
-                    $query->orderByRaw(implode(' + ', $score) . ' desc');
+                if ($scoreExpressions) {
+                    $orderSql = implode(' + ', $scoreExpressions);
+
+                    $query->orderByRaw(
+                        "$orderSql desc",
+                        array_fill(0, substr_count($orderSql, '?'), $q),
+                    );
                 }
         }
 


### PR DESCRIPTION
This PR fixes several PostgreSQL compatibility issues that can result in HTTP 500 errors, while preserving the existing MySQL behavior.

The affected areas include PostgreSQL search and notification queries.

* Fixes the PostgreSQL search HTTP 500 error caused by combining relevance score aliases in the `ORDER BY` expression. PostgreSQL does not allow SELECT aliases to be referenced as operands in an expression at the same query level.
* Fixes the PostgreSQL notification query HTTP 500 error caused by type mismatches when using `COALESCE()` with numeric IDs and text fields.
* Fixes the PostgreSQL notification count expression to use PostgreSQL-compatible string concatenation.
* Fixes comment relevance scoring to use `comments.body` instead of `posts.body`.
* Keeps the existing MySQL behavior unchanged.
* Introduces no additional PostgreSQL extensions or dependencies.
